### PR TITLE
Change boot.sh URL in installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ _RMPC + Cava visualizer_
 ## Installation
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/vyrx-dev/dotfiles/main/boot.sh | bash
+curl -fsSL https://raw.githubusercontent.com/vyrx-dev/symphony/refs/heads/main/boot.sh | bash
 ```
 
 Or manually:


### PR DESCRIPTION
Update the installation command to use the new repository path.